### PR TITLE
Fix man page example for timing multiply

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ using UDP:
 
 ```shell
 drool -vv \
-  -c 'text:timing multiply 2.0; client_pool target "127.0.0.1" "53"; client_pool sendas udp;' \
+  -c 'text:timing multiply 0.5; client_pool target "127.0.0.1" "53"; client_pool sendas udp;' \
   -r file.pcap
 ```
 

--- a/src/drool.1.in
+++ b/src/drool.1.in
@@ -256,7 +256,7 @@ then \fBdrool\fR must be interrupted in order to exit.
 7 \- out of memory
 .SH EXAMPLES
 .TP
-\fBdrool \-vv \-c 'text:timing multiply 2.0; client_pool target "127.0.0.1" "53"; client_pool sendas udp;' \-r file.pcap\fR
+\fBdrool \-vv \-c 'text:timing multiply 0.5; client_pool target "127.0.0.1" "53"; client_pool sendas udp;' \-r file.pcap\fR
 
 Send all DNS queries twice as fast as found in the PCAP file to localhost
 using UDP.


### PR DESCRIPTION
Value 0.5 shortens the interval to one half, i.e. doubles the speed.